### PR TITLE
update from upstream

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -142,7 +142,7 @@ branches:
           - context: "codecov/project"
             app_id: 254
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: false
+      enforce_admins: null
       # Prevent merge commits from being pushed to matching branches
       required_linear_history: false
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,11 @@
             "request": "launch",
             "name": "Debug executable 'logscreen'",
             "cargo": {
-                "args": ["build", "--bin=logscreen", "--package=logscreen"],
+                "args": [
+                    "build",
+                    "--bin=logscreen",
+                    "--package=logscreen"
+                ],
                 "filter": {
                     "name": "logscreen",
                     "kind": "bin"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,15 @@
 {
     "jest.enable": false,
-    "rust-analyzer.runnables.extraEnv": {
-        "RUST_LOG": "DEBUG,socketioxide=INFO,engineioxide=INFO,logscreen=TRACE"
-    },
-    "rust-analyzer.debug.openDebugPane": true,
+    "debug.internalConsoleOptions": "openOnSessionStart",
+    "prettier.configPath": "./.prettierrc.cjs",
     "rust-analyzer.debug.engineSettings": {
         "lldb": {
             "internalConsoleOptions": "openOnSessionStart",
             "terminal": "console"
         }
     },
-    "debug.internalConsoleOptions": "openOnSessionStart"
+    "rust-analyzer.debug.openDebugPane": true,
+    "rust-analyzer.runnables.extraEnv": {
+        "RUST_LOG": "DEBUG,socketioxide=INFO,engineioxide=INFO,logscreen=TRACE"
+    }
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ repository = "https://github.com/kristof-mattei/logscreen"
 [[bin]]
 name = "logscreen"
 path = "back-end/src/main.rs"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lints.clippy]
 # don't stop from compiling / running
@@ -42,7 +41,9 @@ coverage = []
 
 [dependencies]
 axum = { version = "0.7.5" }
-color-eyre = { git = "https://github.com/kristof-mattei/eyre", branch = "bump-backtrace-rs", features = ["track-caller"] }
+color-eyre = { git = "https://github.com/kristof-mattei/eyre", branch = "bump-backtrace-rs", features = [
+    "track-caller",
+] }
 tokio = { version = "1.38.0", features = [
     "macros",
     "io-util",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rust end-to-end application
+# Rust seed application
 
 It's written in Rust!
 

--- a/update-name.sh
+++ b/update-name.sh
@@ -1,31 +1,25 @@
 #!/bin/bash
 
-
 NEW_NAME=$1
 
 FILTERED_NAME=$(echo "${NEW_NAME}" | sed -e "s/[a-z0-9-]//g")
 
-
 echo "New name = ${NEW_NAME}"
-
 
 if [[ ${#FILTERED_NAME} != 0 ]]; then
     echo "Name only allows [a-z0-9-], found ${FILTERED_NAME} (length = ${#FILTERED_NAME})"
     exit 1
 fi
 
-
 NEW_NAME_WITH_UNDERSCORE=$(echo "${NEW_NAME}" | sed -e "s/-/_/g")
 
 echo "New name with underscore = ${NEW_NAME_WITH_UNDERSCORE}"
 
-
-P1="rust-end-to-end-"
-OLD_NAME="${P1}application"
+PART_NAME="rust-"
+OLD_NAME="${PART_NAME}seed"
 OLD_NAME_WITH_UNDERSCORE=$(echo "${OLD_NAME}" | sed -e "s/-/_/g")
 
 echo ${OLD_NAME_WITH_UNDERSCORE}
-
 
 rg --hidden --files-with-matches ${OLD_NAME} | xargs -i sed -i "s/${OLD_NAME}/${NEW_NAME}/g" {}
 rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE}


### PR DESCRIPTION
- **chore(deps): update rust:1.79.0 docker digest to 2c454db**
- **chore(deps): update rui314/setup-mold digest to 65685f4**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.76.0**
- **chore(deps): update docker/build-push-action action to v6**
- **chore(deps): update docker/build-push-action digest to 94f8f8c**
- **chore(deps): update docker/build-push-action action to v6.0.1**
- **chore(deps): update docker/build-push-action action to v6.0.2**
- **chore(deps): update dependency node to v20.15.0**
- **chore(deps): update alpine docker tag to v3.20.1**
- **chore(deps): update docker/build-push-action action to v6.1.0**
- **chore(deps): update dependency @semantic-release/release-notes-generator to v14.0.1**
- **chore: change name**
- **chore(deps): lock file maintenance**
- **chore: separate the name so the rename script doesn't update it**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.77.0**
- **chore(deps): update docker/build-push-action action to v6.2.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.78.0**
- **chore(deps): update github/codeql-action action to v3.25.11**
- **chore(deps): lock file maintenance**
- **chore(deps): update dependency @semantic-release/github to v10.0.7**
- **chore(deps): update rust:1.79.0 docker digest to 4c4f16b**
- **chore(deps): update rust:1.79.0 docker digest to 4c45f61**
- **chore(deps): update docker/build-push-action action to v6.3.0**
- **chore: enforce_admins should be null if you want to disable it...**
- **chore(deps): update docker/setup-buildx-action action to v3.4.0**
